### PR TITLE
Auto generate mutation and query code sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        elixir_version: [1.13.3, 1.14.3, 1.15, 1.16]
+        elixir_version: [1.15, 1.16]
         otp_version: [24, 25, 26]
-        exclude:
-          - otp_version: 25
-            elixir_version: 1.13.3
-          - otp_version: 26
-            elixir_version: 1.13.3
-          - otp_version: 26
-            elixir_version: 1.14.3
     steps:
       - uses: actions/checkout@v4
 

--- a/guides/config.md
+++ b/guides/config.md
@@ -1,0 +1,3 @@
+## Local Development configuration
+
+This section describes the available configuration when working with Graphql Markdown

--- a/guides/config.md
+++ b/guides/config.md
@@ -1,4 +1,0 @@
-## Local Development configuration
-
-This section describes the available configuration when working with Graphql Markdown
-

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -4,6 +4,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
   """
   alias GraphqlMarkdown.OperationDetailsHelpers
 
+  @spec header(String.t(), non_neg_integer(), boolean()) :: String.t()
   def header(text, level, capitalize \\ false)
 
   def header(text, level, true) do
@@ -14,6 +15,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     "#{String.duplicate("#", level)} #{text}"
   end
 
+  @spec list(String.t(), non_neg_integer(), boolean()) :: String.t()
   def list(text, level, capitalize \\ false)
 
   def list(text, level, true) do
@@ -24,6 +26,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     "#{String.duplicate(" ", level * 2)}* #{text}"
   end
 
+  @spec anchor(String.t(), String.t() | nil) :: String.t()
   def anchor(text, anchor_text \\ nil) do
     case anchor_text do
       nil ->
@@ -34,6 +37,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     end
   end
 
+  @spec link(String.t(), String.t() | nil) :: String.t()
   def link(text, url \\ nil) do
     case url do
       nil ->
@@ -44,18 +48,22 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     end
   end
 
+  @spec default_value(any()) :: String.t()
   def default_value(nil), do: ""
 
   def default_value(defaultValue) do
     "The default value is `#{defaultValue}`"
   end
 
+  @spec code(String.t()) :: String.t()
   def code(text), do: "`#{text}`"
 
+  @spec new_line() :: String.t()
   def new_line do
     "\n"
   end
 
+  @spec table(list(), list()) :: String.t()
   def table(fields, rows) do
     headers =
       Enum.join(
@@ -128,11 +136,13 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     """
   end
 
+  @spec capitalize_operation_name(String.t()) :: String.t()
   defp capitalize_operation_name(operation_name) do
     <<first_grapheme::utf8, rest::binary>> = operation_name
     String.capitalize(<<first_grapheme::utf8>>) <> rest
   end
 
+  @spec argument_types_string([OperationDetailsHelpers.argument()]) :: String.t()
   defp argument_types_string([]), do: ""
 
   defp argument_types_string(args) do
@@ -150,6 +160,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     "(#{arg_types})"
   end
 
+  @spec operation_arguments_string([OperationDetailsHelpers.argument()]) :: String.t()
   defp operation_arguments_string([]), do: ""
 
   defp operation_arguments_string(args) do
@@ -161,6 +172,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     "(#{arguments_string})"
   end
 
+  @spec returned_fields(OperationDetailsHelpers.return_type()) :: String.t()
   defp returned_fields(%{kind: "SCALAR"}), do: ""
 
   defp returned_fields(%{kind: "OBJECT"} = return_type) do

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -154,8 +154,8 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
       end
 
     case return_values do
-      "" -> ""
-      _ -> "\n    " <> Enum.join(return_values, "\n    ")
+      [_ | _] -> "\n    " <> Enum.join(return_values, "\n    ")
+      _ -> ""
     end
   end
 end

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -79,4 +79,50 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
 
     headers <> new_line() <> data
   end
+
+  def graphql_operation(operation_details) do
+    %{operation_name: operation_name, operation_type: operation_type, arguments: args} =
+      operation_details
+
+    capitalized_operation_name = capitalize_operation_name(operation_name)
+
+    arguments_types = argument_types_string(args)
+    arguments = operation_arguments_string(args)
+
+    """
+    ```gql
+    #{operation_type} #{capitalized_operation_name}(#{arguments_types}) {
+      #{operation_name}(#{arguments}) {
+      }
+    }
+    ```
+    """
+  end
+
+  defp capitalize_operation_name(operation_name) do
+    <<first_grapheme::utf8, rest::binary>> = operation_name
+    String.capitalize(<<first_grapheme::utf8>>) <> rest
+  end
+
+  defp argument_types_string(args) do
+    args
+    |> Enum.map(fn arg ->
+      arg_type = arg.type
+      arg_name = arg.name
+
+      type_suffix =
+        if arg.required, do: "!", else: ""
+
+      "$#{arg_name}: #{arg_type}#{type_suffix}"
+    end)
+    |> Enum.join(", ")
+  end
+
+  defp operation_arguments_string(args) do
+    args
+    |> Enum.map(fn arg ->
+      "#{arg.name}: $#{arg.name}"
+    end)
+    |> Enum.join(", ")
+  end
 end

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -115,8 +115,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
 
   defp argument_types_string(args) do
     arg_types =
-      args
-      |> Enum.map(fn arg ->
+      Enum.map_join(args, ", ", fn arg ->
         arg_type = arg.type
         arg_name = arg.name
 
@@ -125,7 +124,6 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
 
         "$#{arg_name}: #{arg_type}#{type_suffix}"
       end)
-      |> Enum.join(", ")
 
     "(#{arg_types})"
   end
@@ -134,11 +132,9 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
 
   defp operation_arguments_string(args) do
     arguments_string =
-      args
-      |> Enum.map(fn arg ->
+      Enum.map_join(args, ", ", fn arg ->
         "#{arg.name}: $#{arg.name}"
       end)
-      |> Enum.join(", ")
 
     "(#{arguments_string})"
   end

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -91,8 +91,8 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
 
     """
     ```gql
-    #{operation_type} #{capitalized_operation_name}(#{arguments_types}) {
-      #{operation_name}(#{arguments}) {
+    #{operation_type} #{capitalized_operation_name}#{arguments_types} {
+      #{operation_name}#{arguments} {
       }
     }
     ```
@@ -104,25 +104,35 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     String.capitalize(<<first_grapheme::utf8>>) <> rest
   end
 
+  defp argument_types_string([]), do: ""
+
   defp argument_types_string(args) do
-    args
-    |> Enum.map(fn arg ->
-      arg_type = arg.type
-      arg_name = arg.name
+    arg_types =
+      args
+      |> Enum.map(fn arg ->
+        arg_type = arg.type
+        arg_name = arg.name
 
-      type_suffix =
-        if arg.required, do: "!", else: ""
+        type_suffix =
+          if arg.required, do: "!", else: ""
 
-      "$#{arg_name}: #{arg_type}#{type_suffix}"
-    end)
-    |> Enum.join(", ")
+        "$#{arg_name}: #{arg_type}#{type_suffix}"
+      end)
+      |> Enum.join(", ")
+
+    "(#{arg_types})"
   end
 
+  defp operation_arguments_string([]), do: ""
+
   defp operation_arguments_string(args) do
-    args
-    |> Enum.map(fn arg ->
-      "#{arg.name}: $#{arg.name}"
-    end)
-    |> Enum.join(", ")
+    arguments_string =
+      args
+      |> Enum.map(fn arg ->
+        "#{arg.name}: $#{arg.name}"
+      end)
+      |> Enum.join(", ")
+
+    "(#{arguments_string})"
   end
 end

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -2,6 +2,8 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
   @moduledoc """
   A set of helpers to generate proper markdown easily
   """
+  alias GraphqlMarkdown.OperationDetailsHelpers
+
   def header(text, level, capitalize \\ false)
 
   def header(text, level, true) do
@@ -80,6 +82,26 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     headers <> new_line() <> data
   end
 
+  @doc """
+  Generates a code block for a GraphQL operation. Only the top-level fields returned are represented in the code block.
+  When one of the fields returned is an object, the object's fields are not included in the code block.
+
+  Example:
+    ```gql
+    mutation RefreshIdToken($refreshToken: String!) {
+      refreshIdToken(refreshToken: $refreshToken) {
+        idToken
+        userSsoDetails {
+        }
+      }
+    }
+    ```
+
+    In this example, the `idToken` field is a scalar, so it is included in the code block.
+    In this example the `userSsoDetails` field is an object, so its fields are not included in the code block.
+  """
+  @spec graphql_operation_code_block(OperationDetailsHelpers.graphql_operation_details()) ::
+          String.t()
   def graphql_operation_code_block(operation_details) do
     %{
       operation_name: operation_name,

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -80,7 +80,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
     headers <> new_line() <> data
   end
 
-  def graphql_operation(operation_details) do
+  def graphql_operation_code_block(operation_details) do
     %{
       operation_name: operation_name,
       operation_type: operation_type,

--- a/lib/graphql_markdown/multi_page.ex
+++ b/lib/graphql_markdown/multi_page.ex
@@ -61,6 +61,15 @@ defmodule GraphqlMarkdown.MultiPage do
       data = generate_data(field["args"])
       render(type, MarkdownHelpers.table([field: {}, description: {}], data))
       render_newline(type)
+
+      gql_code_markdown =
+        type
+        |> operation_details(field)
+        |> MarkdownHelpers.graphql_operation()
+
+      render(type, gql_code_markdown)
+
+      render_newline(type)
     end)
   end
 
@@ -176,5 +185,36 @@ defmodule GraphqlMarkdown.MultiPage do
 
   defp render_newline(type) do
     Renderer.render_newline(String.to_existing_atom(type))
+  end
+
+  defp operation_details(type, field) do
+    operation_type =
+      case type do
+        "queries" -> "query"
+        "mutations" -> "mutation"
+      end
+
+    arguments = operation_arguments(field["args"])
+
+    %{
+      operation_type: operation_type,
+      operation_name: field["name"],
+      arguments: arguments,
+      return_type: field["type"]
+    }
+  end
+
+  defp operation_arguments(args) do
+    Enum.map(args, fn arg ->
+      arg_type = arg["type"]
+      type = Schema.field_type(arg_type)
+      required = arg_type["kind"] == "NON_NULL"
+
+      %{
+        name: arg["name"],
+        type: type,
+        required: required
+      }
+    end)
   end
 end

--- a/lib/graphql_markdown/multi_page.ex
+++ b/lib/graphql_markdown/multi_page.ex
@@ -72,7 +72,7 @@ defmodule GraphqlMarkdown.MultiPage do
       gql_code_markdown =
         type
         |> OperationDetailsHelpers.generate_operation_details(field, schema_details)
-        |> MarkdownHelpers.graphql_operation()
+        |> MarkdownHelpers.graphql_operation_code_block()
 
       render(type, gql_code_markdown)
 

--- a/lib/graphql_markdown/operation_details_helpers.ex
+++ b/lib/graphql_markdown/operation_details_helpers.ex
@@ -1,0 +1,100 @@
+defmodule GraphqlMarkdown.OperationDetailsHelpers do
+  @moduledoc """
+  A set of helpers to generate query and mutation details.
+  """
+
+  alias GraphqlMarkdown.Schema
+
+  @type argument :: %{
+          name: String.t(),
+          type: String.t(),
+          required: boolean()
+        }
+
+  @type field :: %{
+          name: String.t(),
+          type: String.t()
+        }
+
+  @type return_type :: %{
+          name: String.t(),
+          kind: String.t(),
+          fields: [field()]
+        }
+
+  @type graphql_operation_details :: %{
+          operation_type: String.t(),
+          operation_name: String.t(),
+          arguments: [argument()],
+          return_type: return_type()
+        }
+
+  @spec generate_operation_details(String.t(), map(), GraphqlMarkdown.Schema.t()) ::
+          graphql_operation_details()
+  def generate_operation_details(type, field, schema_details) do
+    operation_type =
+      case type do
+        "queries" -> "query"
+        "mutations" -> "mutation"
+      end
+
+    arguments = operation_arguments(field["args"])
+
+    operation_details = %{
+      operation_type: operation_type,
+      operation_name: field["name"],
+      arguments: arguments,
+      return_type: return_fields(field["type"], schema_details)
+    }
+
+    operation_details
+  end
+
+  defp operation_arguments(args) do
+    Enum.map(args, fn arg ->
+      arg_type = arg["type"]
+      type = Schema.field_type(arg_type)
+      required = arg_type["kind"] == "NON_NULL"
+
+      %{
+        name: arg["name"],
+        type: type,
+        required: required
+      }
+    end)
+  end
+
+  defp return_fields(%{"name" => name, "kind" => "OBJECT"}, schema_details) do
+    object_fields =
+      schema_details
+      |> Map.get(:objects, [])
+      |> Enum.find(fn object -> object["name"] == name end)
+      |> Map.get("fields", [])
+      |> Enum.map(fn field ->
+        field_name = field["name"]
+        type = return_field_type(field)
+        %{name: field_name, type: type}
+      end)
+
+    %{
+      name: name,
+      kind: "OBJECT",
+      fields: object_fields
+    }
+  end
+
+  defp return_fields(return_type, _schema_details) do
+    %{
+      name: return_type["name"],
+      kind: return_type["kind"]
+    }
+  end
+
+  defp return_field_type(%{"type" => %{"kind" => "NON_NULL"}} = field) do
+    get_in(field, ["type", "ofType", "kind"])
+  end
+
+  defp return_field_type(field) do
+    get_in(field, ["type", "kind"])
+  end
+end

--- a/lib/graphql_markdown/operation_details_helpers.ex
+++ b/lib/graphql_markdown/operation_details_helpers.ex
@@ -29,6 +29,10 @@ defmodule GraphqlMarkdown.OperationDetailsHelpers do
           return_type: return_type()
         }
 
+  @doc """
+  Creates a map with the details of a query or mutation. The details created include
+  the operation type, operation name, arguments, and return type.
+  """
   @spec generate_operation_details(String.t(), map(), GraphqlMarkdown.Schema.t()) ::
           graphql_operation_details()
   def generate_operation_details(type, field, schema_details) do
@@ -50,6 +54,7 @@ defmodule GraphqlMarkdown.OperationDetailsHelpers do
     operation_details
   end
 
+  @spec operation_arguments([map()]) :: [argument()]
   defp operation_arguments(args) do
     Enum.map(args, fn arg ->
       arg_type = arg["type"]
@@ -64,6 +69,7 @@ defmodule GraphqlMarkdown.OperationDetailsHelpers do
     end)
   end
 
+  @spec return_fields(map(), GraphqlMarkdown.Schema.t()) :: return_type()
   defp return_fields(%{"name" => name, "kind" => "OBJECT"}, schema_details) do
     object_fields =
       schema_details
@@ -86,10 +92,12 @@ defmodule GraphqlMarkdown.OperationDetailsHelpers do
   defp return_fields(return_type, _schema_details) do
     %{
       name: return_type["name"],
-      kind: return_type["kind"]
+      kind: return_type["kind"],
+      fields: []
     }
   end
 
+  @spec return_field_type(map()) :: String.t()
   defp return_field_type(%{"type" => %{"kind" => "NON_NULL"}} = field) do
     get_in(field, ["type", "ofType", "kind"])
   end

--- a/lib/graphql_markdown/single_page.ex
+++ b/lib/graphql_markdown/single_page.ex
@@ -3,6 +3,7 @@ defmodule GraphqlMarkdown.SinglePage do
   Single page generator from Graphql to Markdown
   """
   alias GraphqlMarkdown.MarkdownHelpers
+  alias GraphqlMarkdown.OperationDetailsHelpers
   alias GraphqlMarkdown.Renderer
   alias GraphqlMarkdown.Schema
 
@@ -117,7 +118,7 @@ defmodule GraphqlMarkdown.SinglePage do
   end
 
   # Handles Mutations and Queries
-  def generate_section(type, %{"fields" => fields} = _details, _schema_details)
+  def generate_section(type, %{"fields" => fields} = _details, schema_details)
       when type in ["queries", "mutations"] do
     render(MarkdownHelpers.header(type, 2, true))
     render_newline()
@@ -142,7 +143,7 @@ defmodule GraphqlMarkdown.SinglePage do
       render_newline()
 
       type
-      |> operation_details(field)
+      |> OperationDetailsHelpers.generate_operation_details(field, schema_details)
       |> MarkdownHelpers.graphql_operation()
       |> render()
 
@@ -248,36 +249,5 @@ defmodule GraphqlMarkdown.SinglePage do
 
   defp render_newline do
     Renderer.render_newline(:single)
-  end
-
-  defp operation_details(type, field) do
-    operation_type =
-      case type do
-        "queries" -> "query"
-        "mutations" -> "mutation"
-      end
-
-    arguments = operation_arguments(field["args"])
-
-    %{
-      operation_type: operation_type,
-      operation_name: field["name"],
-      arguments: arguments,
-      return_type: field["type"]
-    }
-  end
-
-  defp operation_arguments(args) do
-    Enum.map(args, fn arg ->
-      arg_type = arg["type"]
-      type = Schema.field_type(arg_type)
-      required = arg_type["kind"] == "NON_NULL"
-
-      %{
-        name: arg["name"],
-        type: type,
-        required: required
-      }
-    end)
   end
 end

--- a/lib/graphql_markdown/single_page.ex
+++ b/lib/graphql_markdown/single_page.ex
@@ -144,7 +144,7 @@ defmodule GraphqlMarkdown.SinglePage do
 
       type
       |> OperationDetailsHelpers.generate_operation_details(field, schema_details)
-      |> MarkdownHelpers.graphql_operation()
+      |> MarkdownHelpers.graphql_operation_code_block()
       |> render()
 
       render_newline()

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -129,6 +129,31 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
 
       assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
     end
+
+    test "does not include argument parentheses when there are no arguments" do
+      operation_details = %{
+        arguments: [],
+        operation_name: "currentTime",
+        operation_type: "query",
+        return_type: %{
+          "kind" => "OBJECT",
+          "name" => "CurrentTimeResponse",
+          "ofType" => nil
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        query CurrentTime {
+          currentTime {
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+    end
   end
 
   describe "#default_value" do

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -83,9 +83,11 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         operation_name: "generateLoginCode",
         operation_type: "mutation",
         return_type: %{
-          "kind" => "OBJECT",
-          "name" => "GenerateLoginCodeResponse",
-          "ofType" => nil
+          kind: "OBJECT",
+          name: "GenerateLoginCodeResponse",
+          fields: [
+            %{name: "processed", type: "SCALAR"}
+          ]
         }
       }
 
@@ -94,6 +96,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```gql
         mutation GenerateLoginCode($emailOrPhone: String!) {
           generateLoginCode(emailOrPhone: $emailOrPhone) {
+            processed
           }
         }
         ```
@@ -111,9 +114,12 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         operation_name: "login",
         operation_type: "mutation",
         return_type: %{
-          "kind" => "OBJECT",
-          "name" => "LoginResponse",
-          "ofType" => nil
+          kind: "OBJECT",
+          name: "LoginResponse",
+          fields: [
+            %{name: "idToken", type: "SCALAR"},
+            %{name: "refreshToken", type: "SCALAR"}
+          ]
         }
       }
 
@@ -122,6 +128,41 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```gql
         mutation Login($username: String!, $password: String!) {
           login(username: $username, password: $password) {
+            idToken
+            refreshToken
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+    end
+
+    test "returns an empty object for object an object return type" do
+      operation_details = %{
+        arguments: [
+          %{name: "refreshToken", required: true, type: "String"}
+        ],
+        operation_name: "refreshIdToken",
+        operation_type: "mutation",
+        return_type: %{
+          kind: "OBJECT",
+          name: "RefreshIdTokenResponse",
+          fields: [
+            %{name: "idToken", type: "SCALAR"},
+            %{name: "userSsoDetails", type: "OBJECT"}
+          ]
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        mutation RefreshIdToken($refreshToken: String!) {
+          refreshIdToken(refreshToken: $refreshToken) {
+            idToken
+            userSsoDetails {
+            }
           }
         }
         ```
@@ -136,9 +177,32 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         operation_name: "currentTime",
         operation_type: "query",
         return_type: %{
-          "kind" => "OBJECT",
-          "name" => "CurrentTimeResponse",
-          "ofType" => nil
+          kind: "SCALAR",
+          name: "String"
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        query CurrentTime {
+          currentTime {
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+    end
+
+    test "does not include return fields when the return type is scalar" do
+      operation_details = %{
+        arguments: [],
+        operation_name: "currentTime",
+        operation_type: "query",
+        return_type: %{
+          kind: "SCALAR",
+          name: "String"
         }
       }
 

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -76,7 +76,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
     end
   end
 
-  describe "#graphql_operation" do
+  describe "#graphql_operation_code_block" do
     test "creates a GQL text block for the operation" do
       operation_details = %{
         arguments: [%{name: "emailOrPhone", required: true, type: "String"}],
@@ -102,7 +102,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```
         """
 
-      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
 
     test "returns comma-separated arguments and types when there is more than one argument" do
@@ -135,7 +135,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```
         """
 
-      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
 
     test "returns an empty object for object an object return type" do
@@ -168,7 +168,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```
         """
 
-      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
 
     test "does not include argument parentheses when there are no arguments" do
@@ -192,7 +192,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```
         """
 
-      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
 
     test "does not include return fields when the return type is scalar" do
@@ -216,7 +216,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```
         """
 
-      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
   end
 

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -138,7 +138,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
       assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
 
-    test "returns an empty object for object an object return type" do
+    test "returns an empty object for an object return type" do
       operation_details = %{
         arguments: [
           %{name: "refreshToken", required: true, type: "String"}

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -77,7 +77,7 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
   end
 
   describe "#graphql_operation" do
-    test "Creates a GQL text block for the operation" do
+    test "creates a GQL text block for the operation" do
       operation_details = %{
         arguments: [%{name: "emailOrPhone", required: true, type: "String"}],
         operation_name: "generateLoginCode",
@@ -94,6 +94,34 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
         ```gql
         mutation GenerateLoginCode($emailOrPhone: String!) {
           generateLoginCode(emailOrPhone: $emailOrPhone) {
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+    end
+
+    test "returns comma-separated arguments and types when there is more than one argument" do
+      operation_details = %{
+        arguments: [
+          %{name: "username", required: true, type: "String"},
+          %{name: "password", required: true, type: "String"}
+        ],
+        operation_name: "login",
+        operation_type: "mutation",
+        return_type: %{
+          "kind" => "OBJECT",
+          "name" => "LoginResponse",
+          "ofType" => nil
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        mutation Login($username: String!, $password: String!) {
+          login(username: $username, password: $password) {
           }
         }
         ```

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -76,6 +76,33 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
     end
   end
 
+  describe "#graphql_operation" do
+    test "Creates a GQL text block for the operation" do
+      operation_details = %{
+        arguments: [%{name: "emailOrPhone", required: true, type: "String"}],
+        operation_name: "generateLoginCode",
+        operation_type: "mutation",
+        return_type: %{
+          "kind" => "OBJECT",
+          "name" => "GenerateLoginCodeResponse",
+          "ofType" => nil
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        mutation GenerateLoginCode($emailOrPhone: String!) {
+          generateLoginCode(emailOrPhone: $emailOrPhone) {
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation(operation_details) == expected_text
+    end
+  end
+
   describe "#default_value" do
     test "return nothing when no default value is found as code" do
       assert MarkdownHelpers.default_value(nil) == ""

--- a/test/graphql_markdown/operation_details_helpers_test.exs
+++ b/test/graphql_markdown/operation_details_helpers_test.exs
@@ -1,0 +1,227 @@
+defmodule GraphqlMarkdown.OperationDetailsHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias GraphqlMarkdown.OperationDetailsHelpers
+
+  @generate_login_code_response_object %{
+    "fields" => [
+      %{
+        "args" => [],
+        "deprecationReason" => nil,
+        "description" => nil,
+        "isDeprecated" => false,
+        "name" => "processed",
+        "type" => %{
+          "kind" => "NON_NULL",
+          "name" => nil,
+          "ofType" => %{
+            "kind" => "SCALAR",
+            "name" => "Boolean",
+            "ofType" => nil
+          }
+        }
+      }
+    ],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "GenerateLoginCodeResponse",
+    "possibleTypes" => nil
+  }
+  @generate_login_code_mutation %{
+    "args" => [
+      %{
+        "defaultValue" => nil,
+        "description" => nil,
+        "name" => "emailOrPhone",
+        "type" => %{
+          "kind" => "NON_NULL",
+          "name" => nil,
+          "ofType" => %{
+            "kind" => "SCALAR",
+            "name" => "String",
+            "ofType" => nil
+          }
+        }
+      }
+    ],
+    "deprecationReason" => nil,
+    "description" => nil,
+    "isDeprecated" => false,
+    "name" => "generateLoginCode",
+    "type" => %{
+      "kind" => "OBJECT",
+      "name" => "GenerateLoginCodeResponse",
+      "ofType" => nil
+    }
+  }
+
+  @user_sso_details_object %{
+    "description" => nil,
+    "enumValues" => nil,
+    "fields" => [
+      %{
+        "args" => [],
+        "deprecationReason" => nil,
+        "description" => nil,
+        "isDeprecated" => false,
+        "name" => "domain",
+        "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}
+      },
+      %{
+        "args" => [],
+        "deprecationReason" => nil,
+        "description" => nil,
+        "isDeprecated" => false,
+        "name" => "ssoEnabled",
+        "type" => %{
+          "kind" => "NON_NULL",
+          "name" => nil,
+          "ofType" => %{
+            "kind" => "SCALAR",
+            "name" => "Boolean",
+            "ofType" => nil
+          }
+        }
+      }
+    ],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "UserSsoDetails",
+    "possibleTypes" => nil
+  }
+
+  @user_sso_details_query %{
+    "args" => [
+      %{
+        "defaultValue" => nil,
+        "description" => nil,
+        "name" => "emailOrPhone",
+        "type" => %{
+          "kind" => "NON_NULL",
+          "name" => nil,
+          "ofType" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}
+        }
+      },
+      %{
+        "defaultValue" => nil,
+        "description" => nil,
+        "name" => "includeArchived",
+        "type" => %{
+          "kind" => "SCALAR",
+          "name" => "Boolean",
+          "ofType" => nil
+        }
+      }
+    ],
+    "deprecationReason" => nil,
+    "description" => nil,
+    "isDeprecated" => false,
+    "name" => "userSsoDetails",
+    "type" => %{"kind" => "OBJECT", "name" => "UserSsoDetails", "ofType" => nil}
+  }
+
+  @root_query %{
+    "fields" => [
+      @user_sso_details_query
+    ],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "RootQueryType",
+    "possibleTypes" => nil
+  }
+
+  @root_mutation %{
+    "fields" => [
+      @generate_login_code_mutation
+    ],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "RootMutationType",
+    "possibleTypes" => nil
+  }
+
+  @schema_details %GraphqlMarkdown.Schema{
+    mutations: @root_mutation,
+    queries: @root_query,
+    inputs: [],
+    objects: [
+      @generate_login_code_response_object,
+      @user_sso_details_object
+    ]
+  }
+
+  describe "generate_operation_details/3" do
+    test "returns 'query' as the operation type for queries" do
+      operation_details =
+        OperationDetailsHelpers.generate_operation_details(
+          "queries",
+          @user_sso_details_query,
+          @schema_details
+        )
+
+      assert operation_details.operation_type == "query"
+    end
+
+    test "returns 'mutation' as the operation type for mutations" do
+      operation_details =
+        OperationDetailsHelpers.generate_operation_details(
+          "mutations",
+          @generate_login_code_mutation,
+          @schema_details
+        )
+
+      assert operation_details.operation_type == "mutation"
+    end
+
+    test "returns the operation name" do
+      operation_details =
+        OperationDetailsHelpers.generate_operation_details(
+          "queries",
+          @user_sso_details_query,
+          @schema_details
+        )
+
+      assert operation_details.operation_name == "userSsoDetails"
+    end
+
+    test "returns the arguments for an operation" do
+      expected_arguments = [
+        %{name: "emailOrPhone", required: true, type: "String"},
+        %{name: "includeArchived", required: false, type: "Boolean"}
+      ]
+
+      operation_details =
+        OperationDetailsHelpers.generate_operation_details(
+          "queries",
+          @user_sso_details_query,
+          @schema_details
+        )
+
+      assert operation_details.arguments == expected_arguments
+    end
+
+    test "returns the return type for an operation" do
+      expected_return_type = %{
+        fields: [
+          %{name: "domain", type: "SCALAR"},
+          %{name: "ssoEnabled", type: "SCALAR"}
+        ],
+        kind: "OBJECT",
+        name: "UserSsoDetails"
+      }
+
+      operation_details =
+        OperationDetailsHelpers.generate_operation_details(
+          "queries",
+          @user_sso_details_query,
+          @schema_details
+        )
+
+      assert operation_details.return_type == expected_return_type
+    end
+  end
+end

--- a/test/graphql_markdown/schema_test.exs
+++ b/test/graphql_markdown/schema_test.exs
@@ -3,15 +3,122 @@ defmodule GraphqlMarkdown.SchemaTest do
   alias GraphqlMarkdown.Schema
   doctest GraphqlMarkdown
 
+  @generate_login_code_response %{
+    "fields" => [
+      %{
+        "args" => [],
+        "deprecationReason" => nil,
+        "description" => nil,
+        "isDeprecated" => false,
+        "name" => "processed",
+        "type" => %{
+          "kind" => "NON_NULL",
+          "name" => nil,
+          "ofType" => %{
+            "kind" => "SCALAR",
+            "name" => "Boolean",
+            "ofType" => nil
+          }
+        }
+      }
+    ],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "GenerateLoginCodeResponse",
+    "possibleTypes" => nil
+  }
+  @generate_login_code %{
+    "fields" => [
+      %{
+        "args" => [
+          %{
+            "defaultValue" => nil,
+            "description" => nil,
+            "name" => "emailOrPhone",
+            "type" => %{
+              "kind" => "NON_NULL",
+              "name" => nil,
+              "ofType" => %{
+                "kind" => "SCALAR",
+                "name" => "String",
+                "ofType" => nil
+              }
+            }
+          }
+        ],
+        "deprecationReason" => nil,
+        "description" => nil,
+        "isDeprecated" => false,
+        "name" => "generateLoginCode",
+        "type" => %{
+          "kind" => "OBJECT",
+          "name" => "GenerateLoginCodeResponse",
+          "ofType" => nil
+        }
+      }
+    ]
+  }
+
+  @enum_value %{
+    "fields" => [],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "__EnumValue",
+    "possibleTypes" => nil
+  }
+
+  @root_query %{
+    "fields" => [],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "RootQueryType",
+    "possibleTypes" => nil
+  }
+
+  @root_mutation %{
+    "fields" => [
+      @generate_login_code
+    ],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "RootMutationType",
+    "possibleTypes" => nil
+  }
+
+  @other_type %{
+    "fields" => [],
+    "inputFields" => nil,
+    "interfaces" => [],
+    "kind" => "OBJECT",
+    "name" => "otherType",
+    "possibleTypes" => nil
+  }
+
+  @schema_test %{
+    "mutationType" => %{"name" => "RootMutationType"},
+    "queryType" => %{"name" => "RootQueryType"},
+    "types" => [
+      @generate_login_code_response,
+      @enum_value,
+      @root_query,
+      @root_mutation,
+      @other_type
+    ]
+  }
+
   describe "#mutation_type" do
     test "get the mutation type " do
-      assert Schema.mutation_type(schema_test()) == "RootMutationType"
+      assert Schema.mutation_type(@schema_test) == "RootMutationType"
     end
   end
 
   describe "#query_type" do
     test "get the query type " do
-      assert Schema.query_type(schema_test()) == "someQueryName"
+      assert Schema.query_type(@schema_test) == "RootQueryType"
     end
   end
 
@@ -29,89 +136,33 @@ defmodule GraphqlMarkdown.SchemaTest do
 
   describe "#types" do
     test "find all types and filter __ types" do
-      assert Schema.types(schema_test()) == [
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "someQueryName",
-                 "possibleTypes" => nil
-               },
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "RootMutationType",
-                 "possibleTypes" => nil
-               },
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "otherType",
-                 "possibleTypes" => nil
-               }
+      assert Schema.types(@schema_test) == [
+               @generate_login_code_response,
+               @root_query,
+               @root_mutation,
+               @other_type
              ]
     end
   end
 
   describe "#find_and_sort_type" do
     test "find mutation types" do
-      assert Schema.find_and_sort_type(Schema.types(schema_test()), "name", "RootMutationType") ==
-               [
-                 %{
-                   "fields" => [],
-                   "inputFields" => nil,
-                   "interfaces" => [],
-                   "kind" => "OBJECT",
-                   "name" => "RootMutationType",
-                   "possibleTypes" => nil
-                 }
-               ]
+      assert Schema.find_and_sort_type(Schema.types(@schema_test), "name", "RootMutationType") ==
+               [@root_mutation]
     end
 
     test "find query types" do
-      assert Schema.find_and_sort_type(Schema.types(schema_test()), "name", "someQueryName") == [
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "someQueryName",
-                 "possibleTypes" => nil
-               }
+      assert Schema.find_and_sort_type(Schema.types(@schema_test), "name", "RootQueryType") == [
+               @root_query
              ]
     end
 
     test "find Object types" do
-      assert Schema.find_and_sort_type(Schema.types(schema_test()), "kind", "OBJECT") == [
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "RootMutationType",
-                 "possibleTypes" => nil
-               },
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "otherType",
-                 "possibleTypes" => nil
-               },
-               %{
-                 "fields" => [],
-                 "inputFields" => nil,
-                 "interfaces" => [],
-                 "kind" => "OBJECT",
-                 "name" => "someQueryName",
-                 "possibleTypes" => nil
-               }
+      assert Schema.find_and_sort_type(Schema.types(@schema_test), "kind", "OBJECT") == [
+               @generate_login_code_response,
+               @root_mutation,
+               @root_query,
+               @other_type
              ]
     end
   end
@@ -255,46 +306,4 @@ defmodule GraphqlMarkdown.SchemaTest do
              }) == "String"
     end
   end
-
-  defp schema_test do
-    %{
-      "mutationType" => %{"name" => "RootMutationType"},
-      "queryType" => %{"name" => "someQueryName"},
-      "types" => [
-        %{
-          "fields" => [],
-          "inputFields" => nil,
-          "interfaces" => [],
-          "kind" => "OBJECT",
-          "name" => "__EnumValue",
-          "possibleTypes" => nil
-        },
-        %{
-          "fields" => [],
-          "inputFields" => nil,
-          "interfaces" => [],
-          "kind" => "OBJECT",
-          "name" => "someQueryName",
-          "possibleTypes" => nil
-        },
-        %{
-          "fields" => [],
-          "inputFields" => nil,
-          "interfaces" => [],
-          "kind" => "OBJECT",
-          "name" => "RootMutationType",
-          "possibleTypes" => nil
-        },
-        %{
-          "fields" => [],
-          "inputFields" => nil,
-          "interfaces" => [],
-          "kind" => "OBJECT",
-          "name" => "otherType",
-          "possibleTypes" => nil
-        }
-      ]
-
-    }
-   end
 end

--- a/test/graphql_markdown/schema_test.exs
+++ b/test/graphql_markdown/schema_test.exs
@@ -4,7 +4,7 @@ defmodule GraphqlMarkdown.SchemaTest do
   doctest GraphqlMarkdown
 
   @schema_test %{
-    "mutationType" => %{"name" => "someMutationName"},
+    "mutationType" => %{"name" => "RootMutationType"},
     "queryType" => %{"name" => "someQueryName"},
     "types" => [
       %{
@@ -28,7 +28,7 @@ defmodule GraphqlMarkdown.SchemaTest do
         "inputFields" => nil,
         "interfaces" => [],
         "kind" => "OBJECT",
-        "name" => "someMutationName",
+        "name" => "RootMutationType",
         "possibleTypes" => nil
       },
       %{
@@ -44,7 +44,7 @@ defmodule GraphqlMarkdown.SchemaTest do
 
   describe "#mutation_type" do
     test "get the mutation type " do
-      assert Schema.mutation_type(@schema_test) == "someMutationName"
+      assert Schema.mutation_type(@schema_test) == "RootMutationType"
     end
   end
 
@@ -82,7 +82,7 @@ defmodule GraphqlMarkdown.SchemaTest do
                  "inputFields" => nil,
                  "interfaces" => [],
                  "kind" => "OBJECT",
-                 "name" => "someMutationName",
+                 "name" => "RootMutationType",
                  "possibleTypes" => nil
                },
                %{
@@ -99,14 +99,14 @@ defmodule GraphqlMarkdown.SchemaTest do
 
   describe "#find_and_sort_type" do
     test "find mutation types" do
-      assert Schema.find_and_sort_type(Schema.types(@schema_test), "name", "someMutationName") ==
+      assert Schema.find_and_sort_type(Schema.types(@schema_test), "name", "RootMutationType") ==
                [
                  %{
                    "fields" => [],
                    "inputFields" => nil,
                    "interfaces" => [],
                    "kind" => "OBJECT",
-                   "name" => "someMutationName",
+                   "name" => "RootMutationType",
                    "possibleTypes" => nil
                  }
                ]
@@ -132,7 +132,7 @@ defmodule GraphqlMarkdown.SchemaTest do
                  "inputFields" => nil,
                  "interfaces" => [],
                  "kind" => "OBJECT",
-                 "name" => "otherType",
+                 "name" => "RootMutationType",
                  "possibleTypes" => nil
                },
                %{
@@ -140,7 +140,7 @@ defmodule GraphqlMarkdown.SchemaTest do
                  "inputFields" => nil,
                  "interfaces" => [],
                  "kind" => "OBJECT",
-                 "name" => "someMutationName",
+                 "name" => "otherType",
                  "possibleTypes" => nil
                },
                %{

--- a/test/graphql_markdown/schema_test.exs
+++ b/test/graphql_markdown/schema_test.exs
@@ -3,54 +3,15 @@ defmodule GraphqlMarkdown.SchemaTest do
   alias GraphqlMarkdown.Schema
   doctest GraphqlMarkdown
 
-  @schema_test %{
-    "mutationType" => %{"name" => "RootMutationType"},
-    "queryType" => %{"name" => "someQueryName"},
-    "types" => [
-      %{
-        "fields" => [],
-        "inputFields" => nil,
-        "interfaces" => [],
-        "kind" => "OBJECT",
-        "name" => "__EnumValue",
-        "possibleTypes" => nil
-      },
-      %{
-        "fields" => [],
-        "inputFields" => nil,
-        "interfaces" => [],
-        "kind" => "OBJECT",
-        "name" => "someQueryName",
-        "possibleTypes" => nil
-      },
-      %{
-        "fields" => [],
-        "inputFields" => nil,
-        "interfaces" => [],
-        "kind" => "OBJECT",
-        "name" => "RootMutationType",
-        "possibleTypes" => nil
-      },
-      %{
-        "fields" => [],
-        "inputFields" => nil,
-        "interfaces" => [],
-        "kind" => "OBJECT",
-        "name" => "otherType",
-        "possibleTypes" => nil
-      }
-    ]
-  }
-
   describe "#mutation_type" do
     test "get the mutation type " do
-      assert Schema.mutation_type(@schema_test) == "RootMutationType"
+      assert Schema.mutation_type(schema_test()) == "RootMutationType"
     end
   end
 
   describe "#query_type" do
     test "get the query type " do
-      assert Schema.query_type(@schema_test) == "someQueryName"
+      assert Schema.query_type(schema_test()) == "someQueryName"
     end
   end
 
@@ -68,7 +29,7 @@ defmodule GraphqlMarkdown.SchemaTest do
 
   describe "#types" do
     test "find all types and filter __ types" do
-      assert Schema.types(@schema_test) == [
+      assert Schema.types(schema_test()) == [
                %{
                  "fields" => [],
                  "inputFields" => nil,
@@ -99,7 +60,7 @@ defmodule GraphqlMarkdown.SchemaTest do
 
   describe "#find_and_sort_type" do
     test "find mutation types" do
-      assert Schema.find_and_sort_type(Schema.types(@schema_test), "name", "RootMutationType") ==
+      assert Schema.find_and_sort_type(Schema.types(schema_test()), "name", "RootMutationType") ==
                [
                  %{
                    "fields" => [],
@@ -113,7 +74,7 @@ defmodule GraphqlMarkdown.SchemaTest do
     end
 
     test "find query types" do
-      assert Schema.find_and_sort_type(Schema.types(@schema_test), "name", "someQueryName") == [
+      assert Schema.find_and_sort_type(Schema.types(schema_test()), "name", "someQueryName") == [
                %{
                  "fields" => [],
                  "inputFields" => nil,
@@ -126,7 +87,7 @@ defmodule GraphqlMarkdown.SchemaTest do
     end
 
     test "find Object types" do
-      assert Schema.find_and_sort_type(Schema.types(@schema_test), "kind", "OBJECT") == [
+      assert Schema.find_and_sort_type(Schema.types(schema_test()), "kind", "OBJECT") == [
                %{
                  "fields" => [],
                  "inputFields" => nil,
@@ -294,4 +255,46 @@ defmodule GraphqlMarkdown.SchemaTest do
              }) == "String"
     end
   end
+
+  defp schema_test do
+    %{
+      "mutationType" => %{"name" => "RootMutationType"},
+      "queryType" => %{"name" => "someQueryName"},
+      "types" => [
+        %{
+          "fields" => [],
+          "inputFields" => nil,
+          "interfaces" => [],
+          "kind" => "OBJECT",
+          "name" => "__EnumValue",
+          "possibleTypes" => nil
+        },
+        %{
+          "fields" => [],
+          "inputFields" => nil,
+          "interfaces" => [],
+          "kind" => "OBJECT",
+          "name" => "someQueryName",
+          "possibleTypes" => nil
+        },
+        %{
+          "fields" => [],
+          "inputFields" => nil,
+          "interfaces" => [],
+          "kind" => "OBJECT",
+          "name" => "RootMutationType",
+          "possibleTypes" => nil
+        },
+        %{
+          "fields" => [],
+          "inputFields" => nil,
+          "interfaces" => [],
+          "kind" => "OBJECT",
+          "name" => "otherType",
+          "possibleTypes" => nil
+        }
+      ]
+
+    }
+   end
 end


### PR DESCRIPTION
This updates document generation to include a code block sample for queries and mutations. The code block is included in the section that describes a query or mutation.

The arguments and their types are provided, and a sample of the fields returned is also provided. The sample includes only the first level of fields returned. If any of the fields are objects, then their constituent fields are not shown. This is to prevent needing to traverse arbitrary levels of fields.

Here is an example

```gql
mutation RefreshIdToken($refreshToken: String!) {
  refreshIdToken(refreshToken: $refreshToken) {
    idToken
    userSsoDetails {
    }
  }
}
```

Within a section for that mutation, it would look like this:

![Screenshot 2024-06-23 at 4 17 46 PM](https://github.com/podium/graphql_markdown/assets/3824492/0e00cc97-e803-461b-ae45-293161cd0c71)

### What's missing

- This does not provide sample arguments for an operation.
- It also does not provide samples for union return types.

