### PR TITLE
bugfix: Downcase MultiPage Anchors for Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1 - 2024-09-25
+
+### Fixed
+
+* Links to types from queries/mutations sets anchor properly
+
 ## 0.4.0 - 2024-08-26
 
 ### Added

--- a/lib/graphql_markdown/multi_page.ex
+++ b/lib/graphql_markdown/multi_page.ex
@@ -181,20 +181,22 @@ defmodule GraphqlMarkdown.MultiPage do
   end
 
   defp reference_for_kind(field) do
-    case Schema.field_kind(field["type"]) do
-      "OBJECT" ->
-        "objects.html#" <> Schema.field_type(field["type"])
+    reference =
+      case Schema.field_kind(field["type"]) do
+        "OBJECT" ->
+          "objects.html#" <> Schema.field_type(field["type"])
 
-      "INPUT_OBJECT" ->
-        "inputs.html#" <> Schema.field_type(field["type"])
+        "INPUT_OBJECT" ->
+          "inputs.html#" <> Schema.field_type(field["type"])
 
-      "ENUM" ->
-        "enums.html#" <> Schema.field_type(field["type"])
+        "ENUM" ->
+          "enums.html#" <> Schema.field_type(field["type"])
 
-      _ ->
-        "scalars.html#" <> Schema.field_type(field["type"])
-    end
-    |> String.downcase()
+        _ ->
+          "scalars.html#" <> Schema.field_type(field["type"])
+      end
+
+    String.downcase(reference)
   end
 
   defp render(type, text) do

--- a/lib/graphql_markdown/multi_page.ex
+++ b/lib/graphql_markdown/multi_page.ex
@@ -194,6 +194,7 @@ defmodule GraphqlMarkdown.MultiPage do
       _ ->
         "scalars.html#" <> Schema.field_type(field["type"])
     end
+    |> String.downcase()
   end
 
   defp render(type, text) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GraphqlMarkdown.MixProject do
   use Mix.Project
 
   @project_url "https://github.com/podium/graphql_markdown"
-  @version "0.4.0"
+  @version "0.4.1"
 
   def project do
     [

--- a/test/graphql_markdown_test.exs
+++ b/test/graphql_markdown_test.exs
@@ -40,6 +40,7 @@ defmodule GraphqlMarkdownTest do
       assert content =~ "# Other title"
     end
 
+    @tag :wip
     test "convert schema to markdown as multipage" do
       assert GraphqlMarkdown.generate(
                schema: "test/fixtures/schema.json",
@@ -77,6 +78,10 @@ defmodule GraphqlMarkdownTest do
                   "guides/interfaces.md",
                   "guides/unions.md"
                 ]}
+
+      # anchors need to be downcased to match other parts of the generated markdown
+      content = File.read!("guides/queries.md")
+      assert content =~ "Type: [Droid](scalars.html#droid)"
     end
 
     test "fails to load the file" do

--- a/test/graphql_markdown_test.exs
+++ b/test/graphql_markdown_test.exs
@@ -40,7 +40,6 @@ defmodule GraphqlMarkdownTest do
       assert content =~ "# Other title"
     end
 
-    @tag :wip
     test "convert schema to markdown as multipage" do
       assert GraphqlMarkdown.generate(
                schema: "test/fixtures/schema.json",


### PR DESCRIPTION
This matches how we downcase in generating anchors: https://github.com/podium/graphql_markdown/blob/master/lib/graphql_markdown/markdown_helpers.ex#L30

So that clicking from e.g. query to return type object will deep link properly.