### PR TITLE
bugfix: Handle NonNull/List Types Properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.3 - 2024-09-27
+
+### Fixed
+
+* Fixes where NonNull and ListTypes were defaulting to scalar types for anchor links
+
 ## 0.4.2 - 2024-09-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `graphql_markdown` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:graphql_markdown, "~> 0.1.2"}
+    {:graphql_markdown, "~> 0.4.3"}
   ]
 end
 ```

--- a/lib/graphql_markdown/schema.ex
+++ b/lib/graphql_markdown/schema.ex
@@ -64,10 +64,10 @@ defmodule GraphqlMarkdown.Schema do
   def field_kind(type) do
     case type["kind"] do
       "NON_NULL" ->
-        field_type(type["ofType"])
+        field_kind(type["ofType"])
 
       "LIST" ->
-        field_type(type["ofType"])
+        field_kind(type["ofType"])
 
       _ ->
         type["kind"]

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GraphqlMarkdown.MixProject do
   use Mix.Project
 
   @project_url "https://github.com/podium/graphql_markdown"
-  @version "0.4.2"
+  @version "0.4.3"
 
   def project do
     [

--- a/test/graphql_markdown_test.exs
+++ b/test/graphql_markdown_test.exs
@@ -80,7 +80,7 @@ defmodule GraphqlMarkdownTest do
 
       # anchors need to be downcased to match other parts of the generated markdown
       content = File.read!("guides/queries.md")
-      assert content =~ "Type: [Droid](scalars.html#droid)"
+      assert content =~ "Type: [Droid](objects.html#droid)"
 
       # union types need to be a valid type for links
       content = File.read!("guides/mutations.md")


### PR DESCRIPTION
Fixes where NonNull and ListTypes were defaulting to scalar types, because we were returning field_type for their kind, which is just that objects name.

Looking at the `schema.json` fixture for Droid (updated test):

```json
{
  "args": [
    {
      "defaultValue": null,
      "description": null,
      "name": "episode",
      "type": {
        "kind": "NON_NULL",
        "name": null,
        "ofType": {
          "kind": "SCALAR",
          "name": "String",
          "ofType": null
        }
      }
    }
  ],
  "deprecationReason": null,
  "description": "Get droids for episode",
  "isDeprecated": false,
  "name": "droidsInEpisode",
  "type": {
    "kind": "LIST",
    "name": null,
    "ofType": {
      "kind": "OBJECT",
      "name": "Droid",
      "ofType": null
    }
  }
}
```

Previously, the `field_kind` function would return `Droid`. Now, it will properly return `OBJECT` and links will render properly.