### PR TITLE
fix: add support for NON_NULL GraphQL types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.1 - 2025-03-11
+
+### Fixed
+
+* Add support for NON_NULL GraphQL types
+
 ## 0.5.0 - 2024-10-01
 
 ### Changed

--- a/lib/graphql_markdown/markdown_helpers.ex
+++ b/lib/graphql_markdown/markdown_helpers.ex
@@ -245,4 +245,7 @@ defmodule GraphqlMarkdown.MarkdownHelpers do
 
     shared_fields_string <> specific_types_string
   end
+
+  defp returned_fields(%{kind: "NON_NULL", ofType: inner_type}), do: returned_fields(inner_type)
+  defp returned_fields(%{kind: "NON_NULL"}), do: []
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GraphqlMarkdown.MixProject do
   use Mix.Project
 
   @project_url "https://github.com/podium/graphql_markdown"
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [

--- a/test/graphql_markdown/markdown_helpers_test.exs
+++ b/test/graphql_markdown/markdown_helpers_test.exs
@@ -218,6 +218,64 @@ defmodule GraphqlMarkdown.MarkdownHelpersTest do
 
       assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
     end
+
+    test "handles NON_NULL return type by unwrapping to the inner type" do
+      operation_details = %{
+        arguments: [],
+        operation_name: "requiredField",
+        operation_type: "query",
+        return_type: %{
+          kind: "NON_NULL",
+          name: nil,
+          ofType: %{
+            kind: "OBJECT",
+            name: "RequiredResponse",
+            fields: [
+              %{name: "isRequired", type: "SCALAR"},
+              %{name: "metadata", type: "SCALAR"}
+            ]
+          }
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        query RequiredField {
+          requiredField {
+            isRequired
+            metadata
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
+    end
+
+    test "handles NON_NULL return type without ofType field" do
+      operation_details = %{
+        arguments: [],
+        operation_name: "emptyRequired",
+        operation_type: "query",
+        return_type: %{
+          kind: "NON_NULL",
+          name: "String"
+        }
+      }
+
+      expected_text =
+        """
+        ```gql
+        query EmptyRequired {
+          emptyRequired {
+          }
+        }
+        ```
+        """
+
+      assert MarkdownHelpers.graphql_operation_code_block(operation_details) == expected_text
+    end
   end
 
   describe "#default_value" do


### PR DESCRIPTION
### Changes

```
** (FunctionClauseError) no function clause matching in GraphqlMarkdown.MarkdownHelpers.returned_fields/1

    The following arguments were given to GraphqlMarkdown.MarkdownHelpers.returned_fields/1:

        # 1
        %{name: nil, fields: [], kind: "NON_NULL"}

    Attempted function clauses (showing 4 out of 4):

        defp returned_fields(-%{kind: "SCALAR"}-)
        defp returned_fields(+%{kind: kind} = return_type+) when -kind === "OBJECT"- or -kind === "LIST"-
        defp returned_fields(-%{kind: "UNION"} = return_type-)
        defp returned_fields(-%{kind: "INTERFACE"} = return_type-)

    (graphql_markdown 0.5.0) lib/graphql_markdown/markdown_helpers.ex:176: GraphqlMarkdown.MarkdownHelpers.returned_fields/1
    (graphql_markdown 0.5.0) lib/graphql_markdown/markdown_helpers.ex:127: GraphqlMarkdown.MarkdownHelpers.graphql_operation_code_block/1
    (graphql_markdown 0.5.0) lib/graphql_markdown/multi_page.ex:85: anonymous fn/3 in GraphqlMarkdown.MultiPage.generate_section/3
    (elixir 1.16.3) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (graphql_markdown 0.5.0) lib/graphql_markdown/multi_page.ex:32: anonymous fn/4 in GraphqlMarkdown.MultiPage.render_schema/2
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (graphql_markdown 0.5.0) lib/graphql_markdown.ex:17: GraphqlMarkdown.generate/1
processing urls for guides/graphql_external/enums.md
```

Add support for NON_NULL GraphQL types