### PR TITLE
fix: open files with :utf8 encoding to support non-ASCII characters in field descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.3 - 2026-04-15
+
+### Fixed
+
+* Fix crash when writing non-ASCII characters (e.g. em dash) to file on systems with non-UTF-8 locale
+
 ## 0.5.2 - 2025-12-30
 
 ### Fixed

--- a/lib/graphql_markdown/renderer.ex
+++ b/lib/graphql_markdown/renderer.ex
@@ -32,7 +32,7 @@ defmodule GraphqlMarkdown.Renderer do
           %{fileio: :stdio}
 
         filename ->
-          fileio = File.open!(filename, [:write])
+          fileio = File.open!(filename, [:write, :utf8])
           %{fileio: fileio, filename: filename}
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GraphqlMarkdown.MixProject do
   use Mix.Project
 
   @project_url "https://github.com/podium/graphql_markdown"
-  @version "0.5.2"
+  @version "0.5.3"
 
   def project do
     [

--- a/test/fixtures/unicode_schema.json
+++ b/test/fixtures/unicode_schema.json
@@ -1,0 +1,57 @@
+{
+  "data": {
+    "__schema": {
+      "description": null,
+      "directives": [],
+      "mutationType": null,
+      "queryType": { "name": "RootQueryType" },
+      "subscriptionType": null,
+      "types": [
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "Invoice UID \u2014 required when job_uid is absent",
+              "name": "invoiceUid",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "InvoiceInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Fetch an invoice",
+              "isDeprecated": false,
+              "name": "invoice",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "RootQueryType",
+          "possibleTypes": null
+        }
+      ]
+    }
+  }
+}

--- a/test/graphql_markdown_test.exs
+++ b/test/graphql_markdown_test.exs
@@ -102,5 +102,17 @@ defmodule GraphqlMarkdownTest do
                %Jason.DecodeError{}
              } = GraphqlMarkdown.generate(schema: "test/fixtures/invalid_json_schema.json")
     end
+
+    test "writes non-ASCII characters (em dash) to file without crashing" do
+      assert {:ok, _files} =
+               GraphqlMarkdown.generate(
+                 schema: "test/fixtures/unicode_schema.json",
+                 output_dir: "guides",
+                 multi_page: true
+               )
+
+      content = File.read!("guides/inputs.md")
+      assert content =~ "Invoice UID \u2014 required when job_uid is absent"
+    end
   end
 end


### PR DESCRIPTION
  ## Summary

  - `File.open!/2` defaults to latin1 encoding. In CI containers where the
    system locale is not UTF-8, writing non-ASCII characters (e.g. em dash `—`,
    U+2014) in a field description causes the GenServer to crash with:
    `** (ErlangError) Erlang error: :no_translation`
  - Fix: add `:utf8` to the `File.open!` options in `GraphqlMarkdown.Renderer`
  - Adds a regression test with a minimal fixture schema containing an em dash
    in a field description

  ## Test plan

  - [x] New test reproduces the crash on unpatched code
  - [x] Test passes after the fix
  - [x] All existing tests pass (`mix test`)
  - [x] No other `File.open` calls exist in the library